### PR TITLE
Improve ability to interact with Action through the ActionProxy

### DIFF
--- a/src/Features/ActionProxy.php
+++ b/src/Features/ActionProxy.php
@@ -27,9 +27,23 @@ class ActionProxy
         $this->action = $action;
     }
 
+    public function __get(string $name)
+    {
+        return $this->action->$name;
+    }
+
+    public function __set($name, $value)
+    {
+        $this->action->$name = $value;
+    }
+
     public function __call($name, $arguments)
     {
-        return call_user_func_array([$this, $name.'Proxy'], $arguments);
+        if (method_exists($this, $name . 'Proxy')) {
+            return call_user_func_array([$this, $name . 'Proxy'], $arguments);
+        }
+
+        return call_user_func_array([$this->action, $name], $arguments);
     }
 
     /**

--- a/tests/Unit/ActionsTest.php
+++ b/tests/Unit/ActionsTest.php
@@ -105,6 +105,19 @@ class ActionsTest extends TestCase
         Lantern::setUp(FeatureWithMissingMethods::class);
         ActionMissingMethods::make()->perform();
     }
+
+    #[Test]
+    public function canCallMethodsAndPropertiesOnActionThroughProxy()
+    {
+        Lantern::setUp(AllFeatures::class);
+        $action = ActionWithPropertiesAndMethodsToCall::make();
+
+        $this->assertTrue($action->visible);
+        $this->assertTrue($action->isVisible());
+        $action->visible = false;
+        $this->assertFalse($action->visible);
+        $this->assertFalse($action->isVisible());
+    }
 }
 
 
@@ -178,6 +191,17 @@ class ActionUsingCustomAvailabilityBuilder extends Action
     }
 }
 
+class ActionWithPropertiesAndMethodsToCall extends Action
+{
+    const GUEST_USERS = true;
+    public $visible = true;
+
+    public function isVisible()
+    {
+        return $this->visible;
+    }
+}
+
 class AllFeatures extends Feature
 {
     const ACTIONS = [
@@ -186,6 +210,7 @@ class AllFeatures extends Feature
         ActionWithFailingAvailability::class,
         ActionWithPassingAvailability::class,
         ActionUsingCustomAvailabilityBuilder::class,
+        ActionWithPropertiesAndMethodsToCall::class,
     ];
 }
 


### PR DESCRIPTION
`ActionProxy` will now pass through all property calls and method calls to the `Action`, but still intercept calls to `prepare` and `perform` to ensure availability of the `Action`.